### PR TITLE
Added SQS message deletion to FilteringMessageReader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ## TBD
 ### Fixed
-* Moved SQS message deletion from `MessageReaderAdapter` to `FilteringMessageReader` to mimic previous behaviour and delete all messages, even if they are filtered.
+* `FilteringMessageReader` now deletes filtered messages to mimic previous behaviour of delete on read.
 
 ## [2.0.0] - 2019-04-16
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## TBD
+### Fixed
+* Moved SQS message deletion from `MessageReaderAdapter` to `FilteringMessageReader` to mimic previous behaviour and delete all messages, even if they are filtered.
+
 ## [2.0.0] - 2019-04-16
 ### Added
 * Support for specifying target database and table name.

--- a/shunting-yard-replicator/src/main/java/com/hotels/shunting/yard/replicator/exec/messaging/FilteringMessageReader.java
+++ b/shunting-yard-replicator/src/main/java/com/hotels/shunting/yard/replicator/exec/messaging/FilteringMessageReader.java
@@ -41,10 +41,14 @@ public class FilteringMessageReader implements MessageReader {
   @Override
   public Optional<MessageEvent> read() {
     Optional<MessageEvent> event = delegate.read();
-    event.ifPresent(e -> delete(e));
-    if (event.isPresent() && tableSelector.canProcess(event.get().getEvent())) {
+    if (!event.isPresent()) {
+      return Optional.empty();
+    }
+    MessageEvent messageEvent = event.get();
+    if (tableSelector.canProcess(messageEvent.getEvent())) {
       return event;
     } else {
+      delete(messageEvent);
       return Optional.empty();
     }
   }

--- a/shunting-yard-replicator/src/main/java/com/hotels/shunting/yard/replicator/exec/messaging/MessageReaderAdapter.java
+++ b/shunting-yard-replicator/src/main/java/com/hotels/shunting/yard/replicator/exec/messaging/MessageReaderAdapter.java
@@ -21,9 +21,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Optional;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.expedia.apiary.extensions.receiver.common.event.AddPartitionEvent;
 import com.expedia.apiary.extensions.receiver.common.event.AlterPartitionEvent;
 import com.expedia.apiary.extensions.receiver.common.event.AlterTableEvent;
@@ -33,7 +30,6 @@ import com.expedia.apiary.extensions.receiver.common.event.InsertTableEvent;
 import com.expedia.apiary.extensions.receiver.common.event.ListenerEvent;
 import com.expedia.apiary.extensions.receiver.common.messaging.MessageEvent;
 import com.expedia.apiary.extensions.receiver.common.messaging.MessageReader;
-import com.expedia.apiary.extensions.receiver.sqs.messaging.SqsMessageProperty;
 
 import com.hotels.bdp.circustrain.api.conf.ReplicationMode;
 import com.hotels.shunting.yard.replicator.exec.conf.ShuntingYardTableReplicationsMap;
@@ -41,7 +37,6 @@ import com.hotels.shunting.yard.replicator.exec.conf.ct.ShuntingYardTableReplica
 import com.hotels.shunting.yard.replicator.exec.event.MetaStoreEvent;
 
 public class MessageReaderAdapter implements MetaStoreEventReader {
-  private static final Logger log = LoggerFactory.getLogger(MessageReaderAdapter.class);
 
   private final MessageReader messageReader;
   private final String sourceHiveMetastoreUris;
@@ -66,19 +61,9 @@ public class MessageReaderAdapter implements MetaStoreEventReader {
     Optional<MessageEvent> event = messageReader.read();
     if (event.isPresent()) {
       MessageEvent messageEvent = event.get();
-      deleteMessage(messageEvent);
       return Optional.of(map(messageEvent.getEvent()));
     } else {
       return Optional.empty();
-    }
-  }
-
-  private void deleteMessage(MessageEvent event) {
-    try {
-      messageReader.delete(event);
-      log.debug("Message deleted successfully");
-    } catch (Exception e) {
-      log.error("Could not delete message from queue: ", e);
     }
   }
 

--- a/shunting-yard-replicator/src/main/java/com/hotels/shunting/yard/replicator/exec/messaging/MessageReaderAdapter.java
+++ b/shunting-yard-replicator/src/main/java/com/hotels/shunting/yard/replicator/exec/messaging/MessageReaderAdapter.java
@@ -61,6 +61,7 @@ public class MessageReaderAdapter implements MetaStoreEventReader {
     Optional<MessageEvent> event = messageReader.read();
     if (event.isPresent()) {
       MessageEvent messageEvent = event.get();
+      messageReader.delete(event.get());
       return Optional.of(map(messageEvent.getEvent()));
     } else {
       return Optional.empty();

--- a/shunting-yard-replicator/src/test/java/com/hotels/shunting/yard/replicator/exec/messaging/FilteringMessageReaderTest.java
+++ b/shunting-yard-replicator/src/test/java/com/hotels/shunting/yard/replicator/exec/messaging/FilteringMessageReaderTest.java
@@ -16,6 +16,8 @@
 package com.hotels.shunting.yard.replicator.exec.messaging;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -28,9 +30,9 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
+import com.expedia.apiary.extensions.receiver.common.event.ListenerEvent;
 import com.expedia.apiary.extensions.receiver.common.messaging.MessageEvent;
 import com.expedia.apiary.extensions.receiver.common.messaging.MessageReader;
-import com.expedia.apiary.extensions.receiver.common.event.ListenerEvent;
 
 import com.hotels.shunting.yard.replicator.exec.receiver.TableSelector;
 
@@ -88,6 +90,9 @@ public class FilteringMessageReaderTest {
     event = filteringMessageReader.read().get().getEvent();
     assertThat(event.getDbName()).isEqualTo(DB_NAME);
     assertThat(event.getTableName()).isEqualTo(TABLE_NAME3);
+    verify(delegate).delete(messageEvent1);
+    verify(delegate).delete(messageEvent2);
+    verify(delegate).delete(messageEvent3);
   }
 
   @Test
@@ -108,17 +113,30 @@ public class FilteringMessageReaderTest {
     event = filteringMessageReader.read().get().getEvent();
     assertThat(event.getDbName()).isEqualTo(DB_NAME);
     assertThat(event.getTableName()).isEqualTo(TABLE_NAME3);
+    verify(delegate).delete(messageEvent1);
+    verify(delegate).delete(messageEvent2);
+    verify(delegate).delete(messageEvent3);
   }
 
   @Test
   public void emptyDelegateReader() {
     filteringMessageReader = new FilteringMessageReader(delegate, tableSelector);
     assertThat(filteringMessageReader.read()).isEqualTo(Optional.empty());
+    verify(delegate).delete(messageEvent1);
   }
 
   @Test
   public void typicalDelete() {
     filteringMessageReader = new FilteringMessageReader(delegate, tableSelector);
+    filteringMessageReader.delete(messageEvent1);
+    verify(delegate).delete(messageEvent1);
+  }
+
+  @Test
+  public void deleteThrowsException() {
+    filteringMessageReader = new FilteringMessageReader(delegate, tableSelector);
+    doThrow(new RuntimeException()).when(delegate)
+        .delete(any());
     filteringMessageReader.delete(messageEvent1);
     verify(delegate).delete(messageEvent1);
   }

--- a/shunting-yard-replicator/src/test/java/com/hotels/shunting/yard/replicator/exec/messaging/FilteringMessageReaderTest.java
+++ b/shunting-yard-replicator/src/test/java/com/hotels/shunting/yard/replicator/exec/messaging/FilteringMessageReaderTest.java
@@ -90,9 +90,7 @@ public class FilteringMessageReaderTest {
     event = filteringMessageReader.read().get().getEvent();
     assertThat(event.getDbName()).isEqualTo(DB_NAME);
     assertThat(event.getTableName()).isEqualTo(TABLE_NAME3);
-    verify(delegate).delete(messageEvent1);
     verify(delegate).delete(messageEvent2);
-    verify(delegate).delete(messageEvent3);
   }
 
   @Test
@@ -114,8 +112,6 @@ public class FilteringMessageReaderTest {
     assertThat(event.getDbName()).isEqualTo(DB_NAME);
     assertThat(event.getTableName()).isEqualTo(TABLE_NAME3);
     verify(delegate).delete(messageEvent1);
-    verify(delegate).delete(messageEvent2);
-    verify(delegate).delete(messageEvent3);
   }
 
   @Test

--- a/shunting-yard-replicator/src/test/java/com/hotels/shunting/yard/replicator/exec/messaging/MessageReaderAdapterTest.java
+++ b/shunting-yard-replicator/src/test/java/com/hotels/shunting/yard/replicator/exec/messaging/MessageReaderAdapterTest.java
@@ -203,7 +203,6 @@ public class MessageReaderAdapterTest {
     MetaStoreEvent actual = messageReaderAdapter.read().get();
 
     assertMetaStoreEvent(expected, actual);
-    verify(messageReader).delete(messageEvent.get());
   }
 
   @Test
@@ -228,7 +227,6 @@ public class MessageReaderAdapterTest {
     MetaStoreEvent actual = messageReaderAdapter.read().get();
 
     assertMetaStoreEvent(expected, actual);
-    verify(messageReader).delete(event.get());
   }
 
   @Test
@@ -255,7 +253,6 @@ public class MessageReaderAdapterTest {
     MetaStoreEvent actual = messageReaderAdapter.read().get();
 
     assertMetaStoreEvent(expected, actual);
-    verify(messageReader).delete(event.get());
   }
 
   @Test
@@ -278,7 +275,6 @@ public class MessageReaderAdapterTest {
     MetaStoreEvent actual = messageReaderAdapter.read().get();
 
     assertMetaStoreEvent(expected, actual);
-    verify(messageReader).delete(event.get());
   }
 
   @Test
@@ -305,7 +301,6 @@ public class MessageReaderAdapterTest {
     MetaStoreEvent actual = messageReaderAdapter.read().get();
 
     assertMetaStoreEvent(expected, actual);
-    verify(messageReader).delete(event.get());
   }
 
   @Test
@@ -331,7 +326,6 @@ public class MessageReaderAdapterTest {
     MetaStoreEvent actual = messageReaderAdapter.read().get();
 
     assertMetaStoreEvent(expected, actual);
-    verify(messageReader).delete(event.get());
   }
 
   @Test
@@ -354,7 +348,6 @@ public class MessageReaderAdapterTest {
     MetaStoreEvent actual = messageReaderAdapter.read().get();
 
     assertMetaStoreEvent(expected, actual);
-    verify(messageReader).delete(event.get());
   }
 
   @Test
@@ -376,7 +369,6 @@ public class MessageReaderAdapterTest {
     MetaStoreEvent actual = messageReaderAdapter.read().get();
 
     assertMetaStoreEvent(expected, actual);
-    verify(messageReader).delete(event.get());
   }
 
   @Test
@@ -401,7 +393,6 @@ public class MessageReaderAdapterTest {
     MetaStoreEvent actual = messageReaderAdapter.read().get();
 
     assertMetaStoreEvent(expected, actual);
-    verify(messageReader).delete(event.get());
   }
 
   @Test
@@ -429,7 +420,6 @@ public class MessageReaderAdapterTest {
     MetaStoreEvent actual = messageReaderAdapter.read().get();
 
     assertMetaStoreEvent(expected, actual);
-    verify(messageReader).delete(event.get());
   }
 
   @Test
@@ -449,7 +439,6 @@ public class MessageReaderAdapterTest {
     MetaStoreEvent actual = messageReaderAdapter.read().get();
 
     assertMetaStoreEvent(expected, actual);
-    verify(messageReader).delete(event.get());
   }
 
   @Test

--- a/shunting-yard-replicator/src/test/java/com/hotels/shunting/yard/replicator/exec/messaging/MessageReaderAdapterTest.java
+++ b/shunting-yard-replicator/src/test/java/com/hotels/shunting/yard/replicator/exec/messaging/MessageReaderAdapterTest.java
@@ -203,6 +203,7 @@ public class MessageReaderAdapterTest {
     MetaStoreEvent actual = messageReaderAdapter.read().get();
 
     assertMetaStoreEvent(expected, actual);
+    verify(messageReader).delete(messageEvent.get());
   }
 
   @Test
@@ -227,6 +228,7 @@ public class MessageReaderAdapterTest {
     MetaStoreEvent actual = messageReaderAdapter.read().get();
 
     assertMetaStoreEvent(expected, actual);
+    verify(messageReader).delete(event.get());
   }
 
   @Test
@@ -253,6 +255,7 @@ public class MessageReaderAdapterTest {
     MetaStoreEvent actual = messageReaderAdapter.read().get();
 
     assertMetaStoreEvent(expected, actual);
+    verify(messageReader).delete(event.get());
   }
 
   @Test
@@ -275,6 +278,7 @@ public class MessageReaderAdapterTest {
     MetaStoreEvent actual = messageReaderAdapter.read().get();
 
     assertMetaStoreEvent(expected, actual);
+    verify(messageReader).delete(event.get());
   }
 
   @Test
@@ -301,6 +305,7 @@ public class MessageReaderAdapterTest {
     MetaStoreEvent actual = messageReaderAdapter.read().get();
 
     assertMetaStoreEvent(expected, actual);
+    verify(messageReader).delete(event.get());
   }
 
   @Test
@@ -326,6 +331,7 @@ public class MessageReaderAdapterTest {
     MetaStoreEvent actual = messageReaderAdapter.read().get();
 
     assertMetaStoreEvent(expected, actual);
+    verify(messageReader).delete(event.get());
   }
 
   @Test
@@ -348,6 +354,7 @@ public class MessageReaderAdapterTest {
     MetaStoreEvent actual = messageReaderAdapter.read().get();
 
     assertMetaStoreEvent(expected, actual);
+    verify(messageReader).delete(event.get());
   }
 
   @Test
@@ -369,6 +376,7 @@ public class MessageReaderAdapterTest {
     MetaStoreEvent actual = messageReaderAdapter.read().get();
 
     assertMetaStoreEvent(expected, actual);
+    verify(messageReader).delete(event.get());
   }
 
   @Test
@@ -393,6 +401,7 @@ public class MessageReaderAdapterTest {
     MetaStoreEvent actual = messageReaderAdapter.read().get();
 
     assertMetaStoreEvent(expected, actual);
+    verify(messageReader).delete(event.get());
   }
 
   @Test
@@ -420,6 +429,7 @@ public class MessageReaderAdapterTest {
     MetaStoreEvent actual = messageReaderAdapter.read().get();
 
     assertMetaStoreEvent(expected, actual);
+    verify(messageReader).delete(event.get());
   }
 
   @Test
@@ -439,6 +449,7 @@ public class MessageReaderAdapterTest {
     MetaStoreEvent actual = messageReaderAdapter.read().get();
 
     assertMetaStoreEvent(expected, actual);
+    verify(messageReader).delete(event.get());
   }
 
   @Test


### PR DESCRIPTION
To keep the message reading flow the same in Shunting Yard as it was prior to the Apiary Receiver being extracted, a delete currently happens in `MessageReaderAdapter`. This is not exactly the same as the previous implementation as this will only delete messages that have _not_ been filtered. In other words, messages that have been filtered by the `FilteringMessageReader` will not be deleted.

To mimic the previous behaviour before a wider piece of work to improve this flow, the deletion needs to happen in the `FilteringMessageReader` when it is read and filtered.