### PR TITLE
Upgraded `hotels-oss-parent` to 4.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [TBD] - TBD
+### Changed
+- Upgraded `hotels-oss-parent` to 4.1.0 (was 4.0.1).
 
 ## [3.0.0] - 2019-06-20
 ### Changed

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.hotels</groupId>
     <artifactId>hotels-oss-parent</artifactId>
-    <version>4.0.1</version>
+    <version>4.1.0</version>
   </parent>
 
   <groupId>com.expediagroup</groupId>
@@ -253,44 +253,4 @@
     </pluginManagement>
   </build>
 
-  <profiles>
-    <profile>
-      <id>sonatype-oss-release</id>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-gpg-plugin</artifactId>
-            <version>1.6</version>
-            <executions>
-              <execution>
-                <id>sign-artifacts</id>
-                <phase>verify</phase>
-                <goals>
-                  <goal>sign</goal>
-                </goals>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-    <profile>
-      <id>doclint-java8-disable</id>
-      <activation>
-        <jdk>[1.8,)</jdk>
-      </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-javadoc-plugin</artifactId>
-            <configuration>
-              <additionalparam>-Xdoclint:none</additionalparam>
-            </configuration>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-  </profiles>
 </project>


### PR DESCRIPTION
This was one of the projects I was testing the latest version of the parent pom out on. From what I can tell everything works fine, we'll need to do a release to test the removal of the GPG plugin but I don't think it's needed here any more.

Once we have a release version of the eg-oss-parent we'll move this over to use that but that's for a different PR ;)