### PR TITLE
SY to perform FULL replication on insert overwrite events

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ nbactions.xml
 # Maven target folder
 target/
 **/dependency-reduced-pom.xml
+*.versionsBackup
 
 # Any left over .svn folders
 .svn/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [3.1.0] - TBD
+### Changed
+- Circus Train `replication-Mode` will be `FULL` for `insert overwrite` operation on source table (was `METADATA_UPDATE`).
+- Circus Train `replication-Mode` will always be `FULL` for `ALTER_PARTITION` event.
+
 ## [3.0.1] - 2019-11-22
 ### Changed
 - Upgraded `hotels-oss-parent` to 4.1.0 (was 4.0.1).

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
   <groupId>com.expediagroup</groupId>
   <artifactId>shunting-yard</artifactId>
-  <version>3.0.2-SNAPSHOT</version>
+  <version>3.1.0-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>Shunting Yard Parent</name>
   <url>https://github.com/ExpediaGroup/shunting-yard</url>

--- a/shunting-yard-binary/pom.xml
+++ b/shunting-yard-binary/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.expediagroup</groupId>
     <artifactId>shunting-yard</artifactId>
-    <version>3.0.2-SNAPSHOT</version>
+    <version>3.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>shunting-yard-binary</artifactId>

--- a/shunting-yard-common/pom.xml
+++ b/shunting-yard-common/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.expediagroup</groupId>
     <artifactId>shunting-yard</artifactId>
-    <version>3.0.2-SNAPSHOT</version>
+    <version>3.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>shunting-yard-common</artifactId>

--- a/shunting-yard-common/pom.xml
+++ b/shunting-yard-common/pom.xml
@@ -48,10 +48,6 @@
         </exclusion>
       </exclusions>
     </dependency>
-    <dependency>
-      <groupId>com.hotels</groupId>
-      <artifactId>hcommon-hive-metastore</artifactId>
-    </dependency>
 
     <!-- Test -->
     <dependency>

--- a/shunting-yard-receiver/pom.xml
+++ b/shunting-yard-receiver/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.expediagroup</groupId>
     <artifactId>shunting-yard</artifactId>
-    <version>3.0.2-SNAPSHOT</version>
+    <version>3.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>shunting-yard-receiver</artifactId>

--- a/shunting-yard-receiver/shunting-yard-receiver-sqs/pom.xml
+++ b/shunting-yard-receiver/shunting-yard-receiver-sqs/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.expediagroup</groupId>
     <artifactId>shunting-yard-receiver</artifactId>
-    <version>3.0.2-SNAPSHOT</version>
+    <version>3.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>shunting-yard-receiver-sqs</artifactId>

--- a/shunting-yard-replicator/pom.xml
+++ b/shunting-yard-replicator/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.expediagroup</groupId>
     <artifactId>shunting-yard</artifactId>
-    <version>3.0.2-SNAPSHOT</version>
+    <version>3.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>shunting-yard-replicator</artifactId>

--- a/shunting-yard-replicator/pom.xml
+++ b/shunting-yard-replicator/pom.xml
@@ -99,10 +99,6 @@
         </exclusion>
       </exclusions>
     </dependency>
-    <dependency>
-      <groupId>com.hotels</groupId>
-      <artifactId>hcommon-hive-metastore</artifactId>
-    </dependency>
 
     <!-- Hibernate for validation annotations -->
     <dependency>

--- a/shunting-yard-replicator/src/main/java/com/expediagroup/shuntingyard/replicator/exec/messaging/MessageReaderAdapter.java
+++ b/shunting-yard-replicator/src/main/java/com/expediagroup/shuntingyard/replicator/exec/messaging/MessageReaderAdapter.java
@@ -149,7 +149,6 @@ public class MessageReaderAdapter implements MetaStoreEventReader {
 
   private boolean isPartitionedTable(String dbName, String tableName) {
     Table sourceTable = null;
-
     try {
       sourceTable = sourceMetastoreClient.getTable(dbName, tableName);
     } catch (TException e) {
@@ -160,7 +159,6 @@ public class MessageReaderAdapter implements MetaStoreEventReader {
       return false;
     }
     return true;
-
   }
 
 }

--- a/shunting-yard-replicator/src/test/java/com/expediagroup/shuntingyard/replicator/exec/messaging/MessageReaderAdapterTest.java
+++ b/shunting-yard-replicator/src/test/java/com/expediagroup/shuntingyard/replicator/exec/messaging/MessageReaderAdapterTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2019 Expedia, Inc.
+ * Copyright (C) 2016-2020 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,20 +30,20 @@ import java.util.Optional;
 import java.util.stream.IntStream;
 
 import org.apache.hadoop.hive.metastore.api.FieldSchema;
+import org.apache.hadoop.hive.metastore.api.MetaException;
+import org.apache.hadoop.hive.metastore.api.NoSuchObjectException;
 import org.apache.hadoop.hive.metastore.api.Partition;
+import org.apache.hadoop.hive.metastore.api.Table;
+import org.apache.thrift.TException;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
-import com.expediagroup.shuntingyard.replicator.exec.conf.ShuntingYardTableReplicationsMap;
-import com.expediagroup.shuntingyard.replicator.exec.conf.ct.ShuntingYardTableReplication;
-import com.expediagroup.shuntingyard.replicator.exec.conf.ct.ShuntingYardTableReplications;
-import com.expediagroup.shuntingyard.replicator.exec.event.MetaStoreEvent;
-import com.expediagroup.shuntingyard.replicator.exec.messaging.MessageReaderAdapter;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
 
 import com.expedia.apiary.extensions.receiver.common.event.AddPartitionEvent;
 import com.expedia.apiary.extensions.receiver.common.event.AlterPartitionEvent;
@@ -58,9 +58,15 @@ import com.expedia.apiary.extensions.receiver.common.messaging.MessageEvent;
 import com.expedia.apiary.extensions.receiver.common.messaging.MessageReader;
 import com.expedia.apiary.extensions.receiver.sqs.messaging.SqsMessageProperty;
 
+import com.expediagroup.shuntingyard.replicator.exec.conf.ShuntingYardTableReplicationsMap;
+import com.expediagroup.shuntingyard.replicator.exec.conf.ct.ShuntingYardTableReplication;
+import com.expediagroup.shuntingyard.replicator.exec.conf.ct.ShuntingYardTableReplications;
+import com.expediagroup.shuntingyard.replicator.exec.event.MetaStoreEvent;
+
 import com.hotels.bdp.circustrain.api.conf.ReplicaTable;
 import com.hotels.bdp.circustrain.api.conf.ReplicationMode;
 import com.hotels.bdp.circustrain.api.conf.SourceTable;
+import com.hotels.hcommon.hive.metastore.client.api.CloseableMetaStoreClient;
 
 @RunWith(MockitoJUnitRunner.class)
 public class MessageReaderAdapterTest {
@@ -92,13 +98,15 @@ public class MessageReaderAdapterTest {
   private @Mock DropTableEvent apiaryDropTableEvent;
 
   private @Mock MessageReader messageReader;
+  private @Mock CloseableMetaStoreClient metaStoreClient;
+  private @Mock Table hiveTable;
   private @Mock Partition partition;
 
   private List<Partition> partitionValues;
   private List<FieldSchema> partitionKeys;
 
   @Before
-  public void init() {
+  public void init() throws MetaException, NoSuchObjectException, TException {
     FieldSchema partitionColumn1 = new FieldSchema("column_1", "string", "");
     FieldSchema partitionColumn2 = new FieldSchema("column_2", "integer", "");
     FieldSchema partitionColumn3 = new FieldSchema("column_3", "string", "");
@@ -123,7 +131,11 @@ public class MessageReaderAdapterTest {
 
     partitionKeys = ImmutableList.of(partitionColumn1, partitionColumn2, partitionColumn3);
     partitionValues = ImmutableList.of(partition);
-    messageReaderAdapter = new MessageReaderAdapter(messageReader, SOURCE_METASTORE_URIS,
+
+    when(hiveTable.getPartitionKeys()).thenReturn(partitionKeys);
+    when(metaStoreClient.getTable(TEST_DB, TEST_TABLE)).thenReturn(hiveTable);
+
+    messageReaderAdapter = new MessageReaderAdapter(messageReader, SOURCE_METASTORE_URIS, metaStoreClient,
         new ShuntingYardTableReplicationsMap(tableReplicationsWrapper));
     when(partition.getValues()).thenReturn(PARTITION_VALUES);
   }
@@ -148,7 +160,7 @@ public class MessageReaderAdapterTest {
 
   @Test
   public void createTableEventWhenTableReplicationsAreNotConfigured() {
-    messageReaderAdapter = new MessageReaderAdapter(messageReader, SOURCE_METASTORE_URIS,
+    messageReaderAdapter = new MessageReaderAdapter(messageReader, SOURCE_METASTORE_URIS, metaStoreClient,
         new ShuntingYardTableReplicationsMap(null));
 
     when(messageReader.read()).thenReturn(newMessageEvent(apiaryCreateTableEvent));
@@ -186,7 +198,7 @@ public class MessageReaderAdapterTest {
     ShuntingYardTableReplications tableReplicationsWrapper = new ShuntingYardTableReplications();
     tableReplicationsWrapper.setTableReplications(tableReplications);
 
-    messageReaderAdapter = new MessageReaderAdapter(messageReader, SOURCE_METASTORE_URIS,
+    messageReaderAdapter = new MessageReaderAdapter(messageReader, SOURCE_METASTORE_URIS, metaStoreClient,
         new ShuntingYardTableReplicationsMap(tableReplicationsWrapper));
 
     Optional<MessageEvent> messageEvent = newMessageEvent(apiaryCreateTableEvent);
@@ -240,8 +252,6 @@ public class MessageReaderAdapterTest {
 
     when(apiaryAlterPartitionEvent.getPartitionKeys()).thenReturn(PARTITION_KEYS_MAP);
     when(apiaryAlterPartitionEvent.getPartitionValues()).thenReturn(PARTITION_VALUES);
-    when(apiaryAlterPartitionEvent.getOldPartitionLocation()).thenReturn(OLD_PARTITION_LOCATION);
-    when(apiaryAlterPartitionEvent.getPartitionLocation()).thenReturn(PARTITION_LOCATION);
     when(apiaryAlterPartitionEvent.getEventType()).thenReturn(EventType.ALTER_PARTITION);
 
     MetaStoreEvent expected = MetaStoreEvent
@@ -283,33 +293,6 @@ public class MessageReaderAdapterTest {
   }
 
   @Test
-  public void metadataOnlySyncEventForPartition() {
-    Optional<MessageEvent> event = newMessageEvent(apiaryAlterPartitionEvent);
-    when(messageReader.read()).thenReturn(event);
-    configureMockedEvent(apiaryAlterPartitionEvent);
-
-    when(apiaryAlterPartitionEvent.getPartitionKeys()).thenReturn(PARTITION_KEYS_MAP);
-    when(apiaryAlterPartitionEvent.getPartitionValues()).thenReturn(PARTITION_VALUES);
-    when(apiaryAlterPartitionEvent.getOldPartitionLocation()).thenReturn(PARTITION_LOCATION);
-    when(apiaryAlterPartitionEvent.getPartitionLocation()).thenReturn(PARTITION_LOCATION);
-    when(apiaryAlterPartitionEvent.getEventType()).thenReturn(EventType.ALTER_PARTITION);
-
-    MetaStoreEvent expected = MetaStoreEvent
-        .builder(EventType.ALTER_PARTITION, TEST_DB, TEST_TABLE, REPLICA_DATABASE, REPLICA_TABLE)
-        .partitionColumns(new ArrayList<String>(PARTITION_KEYS_MAP.keySet()))
-        .partitionValues(PARTITION_VALUES)
-        .replicationMode(ReplicationMode.METADATA_UPDATE)
-        .environmentContext(EMPTY_MAP)
-        .parameters(PARAMETERS)
-        .build();
-
-    MetaStoreEvent actual = messageReaderAdapter.read().get();
-
-    assertMetaStoreEvent(expected, actual);
-    verify(messageReader).delete(event.get());
-  }
-
-  @Test
   public void metadataOnlySyncEventForPartitionWithNullLocations() {
     Optional<MessageEvent> event = newMessageEvent(apiaryAlterPartitionEvent);
     when(messageReader.read()).thenReturn(event);
@@ -317,7 +300,6 @@ public class MessageReaderAdapterTest {
 
     when(apiaryAlterPartitionEvent.getPartitionKeys()).thenReturn(PARTITION_KEYS_MAP);
     when(apiaryAlterPartitionEvent.getPartitionValues()).thenReturn(PARTITION_VALUES);
-    when(apiaryAlterPartitionEvent.getPartitionLocation()).thenReturn(null);
     when(apiaryAlterPartitionEvent.getEventType()).thenReturn(EventType.ALTER_PARTITION);
 
     MetaStoreEvent expected = MetaStoreEvent
@@ -365,6 +347,29 @@ public class MessageReaderAdapterTest {
     configureMockedEvent(apiaryAlterTableEvent);
 
     when(apiaryAlterTableEvent.getTableLocation()).thenReturn(null);
+    when(apiaryAlterTableEvent.getEventType()).thenReturn(EventType.ALTER_TABLE);
+
+    MetaStoreEvent expected = MetaStoreEvent
+        .builder(EventType.ALTER_TABLE, TEST_DB, TEST_TABLE, REPLICA_DATABASE, REPLICA_TABLE)
+        .environmentContext(EMPTY_MAP)
+        .parameters(PARAMETERS)
+        .replicationMode(ReplicationMode.FULL)
+        .build();
+
+    MetaStoreEvent actual = messageReaderAdapter.read().get();
+
+    assertMetaStoreEvent(expected, actual);
+    verify(messageReader).delete(event.get());
+  }
+
+  @Test
+  public void insertOverwriteEventForUnpartitionedTable() throws MetaException, NoSuchObjectException, TException {
+    Optional<MessageEvent> event = newMessageEvent(apiaryAlterTableEvent);
+    when(messageReader.read()).thenReturn(event);
+    configureMockedEvent(apiaryAlterTableEvent);
+
+    when(metaStoreClient.getTable(TEST_DB, TEST_TABLE)).thenReturn(hiveTable);
+    when(hiveTable.getPartitionKeys()).thenReturn(Lists.newArrayList());
     when(apiaryAlterTableEvent.getEventType()).thenReturn(EventType.ALTER_TABLE);
 
     MetaStoreEvent expected = MetaStoreEvent
@@ -460,8 +465,9 @@ public class MessageReaderAdapterTest {
   }
 
   private Optional<MessageEvent> newMessageEvent(ListenerEvent event) {
-    return Optional.of(new MessageEvent(event,
-        Collections.singletonMap(SqsMessageProperty.SQS_MESSAGE_RECEIPT_HANDLE, RECEIPT_HANDLE)));
+    return Optional
+        .of(new MessageEvent(event,
+            Collections.singletonMap(SqsMessageProperty.SQS_MESSAGE_RECEIPT_HANDLE, RECEIPT_HANDLE)));
   }
 
   private void configureMockedEvent(ListenerEvent serializableListenerEvent) {


### PR DESCRIPTION
To achieve this, SY will need to make a callback to Source Hive Metastore to determine if a table is partitioned or not as we don't have that information in ALTER_TABLE event.

ALTER_TABLE event: https://github.com/ExpediaGroup/apiary-extensions/tree/master/apiary-metastore-events/sns-metastore-events/apiary-metastore-listener#alter-table

Other change is that for ALTER_PARTITION event, it will always be a FULL_UPDATE.