### PR TITLE
egdl-1429: update parent 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 # [3.2.0] - TBD
 ### Changed
 - Upgraded shunting-yard parent from `hotels-oss-parent` to `eg-oss-parent`.
-
-# [3.1.1] - TBD
-### Changed
 - Upgraded version of `hive.version` to `2.3.7` (was `2.3.4`). Allows Shunting Yard to be used on JDK>=9.
 
 ## [3.1.0] - 2020-01-16

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+# [3.2.0] - TBD
+### Changed
+- Upgraded parent of shunting-yard from hotels-oss-parent to eg-oss-parent.
+
 # [3.1.1] - TBD
 ### Changed
 - Upgraded version of `hive.version` to `2.3.7` (was `2.3.4`). Allows Shunting Yard to be used on JDK>=9.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-# [3.2.0] - TBD
+## [3.2.0] - TBD
 ### Changed
 - Upgraded shunting-yard parent from `hotels-oss-parent` to `eg-oss-parent`.
 - Upgraded version of `hive.version` to `2.3.7` (was `2.3.4`). Allows Shunting Yard to be used on JDK>=9.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 # [3.2.0] - TBD
 ### Changed
-- Upgraded parent of shunting-yard from hotels-oss-parent to eg-oss-parent.
+- Upgraded shunting-yard parent from `hotels-oss-parent` to `eg-oss-parent`.
 
 # [3.1.1] - TBD
 ### Changed

--- a/pom.xml
+++ b/pom.xml
@@ -2,12 +2,11 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>com.hotels</groupId>
-    <artifactId>hotels-oss-parent</artifactId>
-    <version>4.1.0</version>
+    <groupId>com.expediagroup</groupId>
+    <artifactId>eg-oss-parent</artifactId>
+    <version>2.0.1-SNAPSHOT</version>
   </parent>
 
-  <groupId>com.expediagroup</groupId>
   <artifactId>shunting-yard</artifactId>
   <version>3.1.1-SNAPSHOT</version>
   <packaging>pom</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
   </parent>
 
   <artifactId>shunting-yard</artifactId>
-  <version>3.1.1-SNAPSHOT</version>
+  <version>3.2.0-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>Shunting Yard Parent</name>
   <url>https://github.com/ExpediaGroup/shunting-yard</url>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.expediagroup</groupId>
     <artifactId>eg-oss-parent</artifactId>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>shunting-yard</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.expediagroup</groupId>
     <artifactId>eg-oss-parent</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.1.0</version>
   </parent>
 
   <artifactId>shunting-yard</artifactId>

--- a/shunting-yard-binary/pom.xml
+++ b/shunting-yard-binary/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.expediagroup</groupId>
     <artifactId>shunting-yard</artifactId>
-    <version>3.1.1-SNAPSHOT</version>
+    <version>3.2.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>shunting-yard-binary</artifactId>

--- a/shunting-yard-common/pom.xml
+++ b/shunting-yard-common/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.expediagroup</groupId>
     <artifactId>shunting-yard</artifactId>
-    <version>3.1.1-SNAPSHOT</version>
+    <version>3.2.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>shunting-yard-common</artifactId>

--- a/shunting-yard-receiver/pom.xml
+++ b/shunting-yard-receiver/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.expediagroup</groupId>
     <artifactId>shunting-yard</artifactId>
-    <version>3.1.1-SNAPSHOT</version>
+    <version>3.2.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>shunting-yard-receiver</artifactId>

--- a/shunting-yard-receiver/shunting-yard-receiver-sqs/pom.xml
+++ b/shunting-yard-receiver/shunting-yard-receiver-sqs/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.expediagroup</groupId>
     <artifactId>shunting-yard-receiver</artifactId>
-    <version>3.1.1-SNAPSHOT</version>
+    <version>3.2.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>shunting-yard-receiver-sqs</artifactId>

--- a/shunting-yard-replicator/pom.xml
+++ b/shunting-yard-replicator/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.expediagroup</groupId>
     <artifactId>shunting-yard</artifactId>
-    <version>3.1.1-SNAPSHOT</version>
+    <version>3.2.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>shunting-yard-replicator</artifactId>


### PR DESCRIPTION
These two PRs need to be merged first:
https://github.com/ExpediaGroup/eg-oss-plugin-config/pull/5
https://github.com/ExpediaGroup/eg-oss-parent/pull/11

- Changed the **parent** of shunting-yard to be eg-oss-parent (which also has the latest plugin versions) and not hotels-oss-parent.
- Changed the version from 3.1.1-SNAPSHOT to 3.2.0-SNAPSHOT
- In version 3.1.1 of shunting-yard there was an update in the hive version, but this was never released so it will be implemented in this release too (see changelog).
