### PR TITLE
egdl-1430: update plugins + replace cobertura for jacoco

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 ### Changed
 - Upgraded shunting-yard parent from `hotels-oss-parent` to `eg-oss-parent`.
 - Upgraded version of `hive.version` to `2.3.7` (was `2.3.4`). Allows Shunting Yard to be used on JDK>=9.
+- Cobertura removed and replaced with Jacoco for coverage.
+- Upgraded `common-hive-metastore` from  1.4.2
 
 ## [3.1.0] - 2020-01-16
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 ### Changed
 - Upgraded shunting-yard parent from `hotels-oss-parent` to `eg-oss-parent`.
 - Upgraded version of `hive.version` to `2.3.7` (was `2.3.4`). Allows Shunting Yard to be used on JDK>=9.
-- Cobertura removed and replaced with Jacoco for coverage.
 - Upgraded `hcommon.hive.metastore` from `1.4.1` to `1.4.2`.
 - Upgraded `circus.train` from `15.0.0` to `16.3.0`.
-- Upgraded `beeju.version` from `1.2.0` to `3.1.0`.
-- Upgraded `mockito.version` from `2.10.0` to `3.5.11`.
 - Upgraded AWS SDK (`aws.version`) from `1.11.415` to `1.11.852`.
 - Upgraded `micrometer.version` (in shunting-yard-replicator) from `1.0.5` to `1.5.4`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 - Upgraded shunting-yard parent from `hotels-oss-parent` to `eg-oss-parent`.
 - Upgraded version of `hive.version` to `2.3.7` (was `2.3.4`). Allows Shunting Yard to be used on JDK>=9.
 - Cobertura removed and replaced with Jacoco for coverage.
-- Upgraded `common-hive-metastore` from  1.4.2
+- Upgraded `hcommon.hive.metastore` from `1.4.1` to `1.4.2`.
+- Upgraded `circus.train` from `15.0.0` to `16.3.0`.
+- Upgraded `beeju.version` from `1.2.0` to `3.1.0`.
+- Upgraded `mockito.version` from `2.10.0` to `2.28.2`.
+- Upgraded AWS SDK (`aws.version`) from `1.11.415` to `1.11.852`.
+- Upgraded `micrometer.version` (in shunting-yard-replicator) from `1.0.5` to `1.5.4`.
 
 ## [3.1.0] - 2020-01-16
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 - Upgraded `hcommon.hive.metastore` from `1.4.1` to `1.4.2`.
 - Upgraded `circus.train` from `15.0.0` to `16.3.0`.
 - Upgraded `beeju.version` from `1.2.0` to `3.1.0`.
-- Upgraded `mockito.version` from `2.10.0` to `2.28.2`.
+- Upgraded `mockito.version` from `2.10.0` to `3.5.11`.
 - Upgraded AWS SDK (`aws.version`) from `1.11.415` to `1.11.852`.
 - Upgraded `micrometer.version` (in shunting-yard-replicator) from `1.0.5` to `1.5.4`.
 

--- a/pom.xml
+++ b/pom.xml
@@ -30,8 +30,7 @@
 
   <properties>
     <apiary.receiver.sqs.verison>2.0.0</apiary.receiver.sqs.verison>
-    <cobertura.version>2.0.3</cobertura.version>
-    <cobertura.maven.plugin.version>2.6</cobertura.maven.plugin.version>
+    <!--<jacoco.version>0.8.6</jacoco.version>-->
     <jdk.version>1.8</jdk.version>
     <slf4j.version>1.7.7</slf4j.version>
     <hadoop.version>2.7.2</hadoop.version>

--- a/pom.xml
+++ b/pom.xml
@@ -35,23 +35,23 @@
     <slf4j.version>1.7.7</slf4j.version>
     <hadoop.version>2.7.2</hadoop.version>
     <hive.version>2.3.7</hive.version>
-    <hcommon.hive.metastore.version>1.4.1</hcommon.hive.metastore.version>
+    <hcommon.hive.metastore.version>1.4.2</hcommon.hive.metastore.version>
     <derby.version>10.10.2.0</derby.version>
     <kafka.version>0.11.0.1</kafka.version>
-    <aws.version>1.11.415</aws.version>
+    <aws.version>1.11.852</aws.version>
     <aws.kcl.version>1.9.0</aws.kcl.version>
     <aws.kpl.version>0.12.8</aws.kpl.version>
-    <circus.train.version>15.0.0</circus.train.version>
+    <circus.train.version>16.3.0</circus.train.version>
     <commons.lang3.version>3.7</commons.lang3.version>
     <thrift.version>0.10.0</thrift.version>
     <guava.version>25.0-jre</guava.version>
 
     <junit.version>4.12</junit.version>
     <assertj.version>3.10.0</assertj.version>
-    <mockito.version>2.10.0</mockito.version>
+    <mockito.version>2.28.2</mockito.version>
     <powermock.version>2.0.0-beta.5</powermock.version>
     <lastcommons.version>5.2.1</lastcommons.version>
-    <beeju.version>1.2.0</beeju.version>
+    <beeju.version>3.1.0</beeju.version>
 
     <maven.shade.plugin.version>3.1.1</maven.shade.plugin.version>
     <shade.prefix>${project.groupId}.shaded</shade.prefix>

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,6 @@
 
   <properties>
     <apiary.receiver.sqs.verison>2.0.0</apiary.receiver.sqs.verison>
-    <!--<jacoco.version>0.8.6</jacoco.version>-->
     <jdk.version>1.8</jdk.version>
     <slf4j.version>1.7.7</slf4j.version>
     <hadoop.version>2.7.2</hadoop.version>

--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
 
     <junit.version>4.12</junit.version>
     <assertj.version>3.10.0</assertj.version>
-    <mockito.version>2.28.2</mockito.version>
+    <mockito.version>3.5.11</mockito.version>
     <powermock.version>2.0.0-beta.5</powermock.version>
     <lastcommons.version>5.2.1</lastcommons.version>
     <beeju.version>3.1.0</beeju.version>

--- a/shunting-yard-replicator/pom.xml
+++ b/shunting-yard-replicator/pom.xml
@@ -11,7 +11,7 @@
 
   <properties>
     <spring.platform.version>Brussels-SR10</spring.platform.version>
-    <micrometer.version>1.0.5</micrometer.version>
+    <micrometer.version>1.5.4</micrometer.version>
     <commons.vfs2.version>2.1</commons.vfs2.version>
     <commons.exec.version>1.3</commons.exec.version>
   </properties>


### PR DESCRIPTION
[Ticket egdl-1430](https://jira.expedia.biz/browse/EGDL-1430).
- Update some plugins to specific versions.
- Cobertura removed and replaced with Jacoco for coverage (Jacoco is included in eg-oss-parent).
